### PR TITLE
Add Vint configuration

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,4 @@
+cmdargs:
+  severity: style_problem
+  env:
+    neovim: true

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright © 2014-2017 Scott Stevenson <scott@stevenson.io>
+Copyright © 2014-2018 Scott Stevenson <scott@stevenson.io>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let g:decfile_disable_folding = 1
 
 ## Copyright
 
-Copyright © 2014-2017 [Scott Stevenson].
+Copyright © 2014-2018 [Scott Stevenson].
 
 vim-decfile is distributed under the terms of the [ISC licence].
 


### PR DESCRIPTION
Vint is now configured to enable Neovim syntax, and to also check for style problems.
