### PR TITLE
Use echoerr in place of echomsg

### DIFF
--- a/autoload/decfile.vim
+++ b/autoload/decfile.vim
@@ -12,6 +12,6 @@ function! decfile#CheckIsNumber(variable, name) abort
     " name : String
     "     Name of the variable.
     if type(a:variable) != type(0)
-        echomsg 'Error:' a:name 'must be a number'
+        echoerr 'vim-decfile:' a:name 'must be a number'
     endif
 endfunction


### PR DESCRIPTION
[`echoerr`](https://neovim.io/doc/user/eval.html#:echoerr) echoes the expression as an error message, saving the message in the [message history](https://neovim.io/doc/user/message.html#message-history).