### PR TITLE
Remove `sudo: true` from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: true
 language: python
 python:
   - "3.7"


### PR DESCRIPTION
This is no longer necessary due to [recent Travis CI infrastructure updates](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-is-here!-79690).